### PR TITLE
Fix for Junction implicitly deconting values

### DIFF
--- a/lib/Game/Sudoku.pm6
+++ b/lib/Game/Sudoku.pm6
@@ -85,7 +85,7 @@ class Game::Sudoku:ver<1.1.2>:auth<simon.proctor@gmail.com> {
     }
 
     method valid {
-        $!valid-all := self!compute-valid() unless $!valid-all;
+        $!valid-all := self!compute-valid();
         return %!test-cache<valid> if %!test-cache<valid>:exists;
         %!test-cache<valid> = [&&] (1..9).map( so $!valid-all == * );
     }


### PR DESCRIPTION
The previous version of the code was relying on incorrect `Junction` behavior.

Previously, `Junction` was storing containerized values which was causing some unwanted side effects. It is now decontainerizing all values. Therefore validation must generate new junction for each new state.